### PR TITLE
Quick fix to ignore the intentional overflow

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-clang -o test/static_demo test/static_demo.c
+clang -o test/static_demo -w test/static_demo.c
 clang -o test/dynamic_demo test/dynamic_demo.c
 
 cargo build --release


### PR DESCRIPTION
Otherwise on build.sh :
test/static_demo.c:9:5: warning: 'strcpy' will always overflow; destination buffer has size 8, but the source string has length 18 (including NUL byte) [-Wfortify-source]
    9 |     strcpy(buf, "Really long text!");
      |     ^
test/static_demo.c:10:29: warning: 'scanf' may overflow; destination buffer in argument 2 has size 16, but the corresponding specifier may require size 20 [-Wfortify-source]
   10 |     scanf("This: %19s, %s", new_buf, buf);
      |                             ^
2 warnings generated.
./build.sh: line 6: cargo: command not found
/usr/bin/ld: cannot find -lrust_overflow_sentinel: No such file or directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)